### PR TITLE
Use user specified snapshotId to get table info

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ usage: java -jar <jar_name> [options] command [args]
                                   display
  -h,--help                        Show this help message
  -o,--output <console|csv|json>   Show output in this format
+    --snapshot <snapshot ID>      Snapshot ID to use
  -u,--uri <value>                 Hive metastore to use
  -w,--warehouse <value>           Table location
 

--- a/tools/java-iceberg-cli/src/main/java/iceberg/HiveConnector.java
+++ b/tools/java-iceberg-cli/src/main/java/iceberg/HiveConnector.java
@@ -191,7 +191,7 @@ public class HiveConnector extends MetastoreConnector
     }
     
     @Override
-    public Long currentSnapshotId() throws Exception {
+    public Long getCurrentSnapshotId() throws Exception {
         return null;
     }
     

--- a/tools/java-iceberg-cli/src/main/java/iceberg/HiveConnector.java
+++ b/tools/java-iceberg-cli/src/main/java/iceberg/HiveConnector.java
@@ -187,8 +187,12 @@ public class HiveConnector extends MetastoreConnector
 
     @Override
     public Snapshot getCurrentSnapshot() throws Exception {
-        // TODO Auto-generated method stub
-        throw new Exception("Hive functionaility not supported yet.");
+        return null;
+    }
+    
+    @Override
+    public Long currentSnapshotId() throws Exception {
+        return null;
     }
     
     @Override

--- a/tools/java-iceberg-cli/src/main/java/iceberg/HiveConnector.java
+++ b/tools/java-iceberg-cli/src/main/java/iceberg/HiveConnector.java
@@ -203,8 +203,7 @@ public class HiveConnector extends MetastoreConnector
 
     @Override
     public Iterable<Snapshot> getListOfSnapshots() throws Exception {
-        // TODO Auto-generated method stub
-        throw new Exception("Hive functionaility not supported yet.");
+        return new ArrayList<Snapshot>();
     }
 
     @Override

--- a/tools/java-iceberg-cli/src/main/java/iceberg/IcebergApplication.java
+++ b/tools/java-iceberg-cli/src/main/java/iceberg/IcebergApplication.java
@@ -46,6 +46,7 @@ public class IcebergApplication {
         String tableFormat = parser.tableFormat();
         String outputFormat = parser.outputFormat();
         String schemaJsonString = parser.getPositionalArg("schema");
+        String snapshotId = parser.snapshotId();
         
         // Initialize HiveCatalog
         MetastoreConnector connector;
@@ -55,6 +56,10 @@ public class IcebergApplication {
             connector = new IcebergConnector(uri, warehouse, namespace, tableName);
         else
             throw new ParseException("Unsupported table format: " + tableFormat);
+        
+        // Set user specified snapshot ID, if any
+        if (snapshotId != null)
+            connector.setSnapshotId(Long.valueOf(snapshotId));
         
         PrintUtils printUtils = new PrintUtils(connector, outputFormat);
         // Perform action

--- a/tools/java-iceberg-cli/src/main/java/iceberg/IcebergConnector.java
+++ b/tools/java-iceberg-cli/src/main/java/iceberg/IcebergConnector.java
@@ -288,7 +288,7 @@ public class IcebergConnector extends MetastoreConnector
         return m_scan.snapshot();
     }
     
-    public Long currentSnapshotId() {
+    public Long getCurrentSnapshotId() {
         loadTable();
         
         return m_scan.snapshot().snapshotId();

--- a/tools/java-iceberg-cli/src/main/java/iceberg/IcebergConnector.java
+++ b/tools/java-iceberg-cli/src/main/java/iceberg/IcebergConnector.java
@@ -284,10 +284,14 @@ public class IcebergConnector extends MetastoreConnector
          
     public Snapshot getCurrentSnapshot() {
         loadTable();
-
-        Snapshot snapshot = m_scan.snapshot();
         
-        return snapshot;
+        return m_scan.snapshot();
+    }
+    
+    public Long currentSnapshotId() {
+        loadTable();
+        
+        return m_scan.snapshot().snapshotId();
     }
 
     public java.lang.Iterable<Snapshot> getListOfSnapshots() {

--- a/tools/java-iceberg-cli/src/main/java/iceberg/MetastoreConnector.java
+++ b/tools/java-iceberg-cli/src/main/java/iceberg/MetastoreConnector.java
@@ -30,6 +30,7 @@ import org.apache.iceberg.PartitionField;
 
 public abstract class MetastoreConnector 
 {
+    protected Long m_snapshotId = null;
 
     public MetastoreConnector(String metastoreUri, String warehouse, String namespace, String tableName) {
     }
@@ -76,7 +77,11 @@ public abstract class MetastoreConnector
     
     public abstract PartitionSpec getSpec() throws Exception;
     
-    public abstract String getUUID()  throws Exception; 
+    public abstract String getUUID()  throws Exception;
+    
+    public void setSnapshotId(Long snapshotId) {
+        this.m_snapshotId = snapshotId;
+    }
     
     @SuppressWarnings("serial")
     class TableNotFoundException extends RuntimeException {

--- a/tools/java-iceberg-cli/src/main/java/iceberg/MetastoreConnector.java
+++ b/tools/java-iceberg-cli/src/main/java/iceberg/MetastoreConnector.java
@@ -56,6 +56,8 @@ public abstract class MetastoreConnector
     public abstract String getTableDataLocation() throws Exception;
     
     public abstract Snapshot getCurrentSnapshot() throws Exception;
+    
+    public abstract Long currentSnapshotId() throws Exception;
 
     public abstract Iterable<Snapshot> getListOfSnapshots() throws Exception;
     

--- a/tools/java-iceberg-cli/src/main/java/iceberg/MetastoreConnector.java
+++ b/tools/java-iceberg-cli/src/main/java/iceberg/MetastoreConnector.java
@@ -57,7 +57,7 @@ public abstract class MetastoreConnector
     
     public abstract Snapshot getCurrentSnapshot() throws Exception;
     
-    public abstract Long currentSnapshotId() throws Exception;
+    public abstract Long getCurrentSnapshotId() throws Exception;
 
     public abstract Iterable<Snapshot> getListOfSnapshots() throws Exception;
     

--- a/tools/java-iceberg-cli/src/main/java/iceberg/cli/OptionsParser.java
+++ b/tools/java-iceberg-cli/src/main/java/iceberg/cli/OptionsParser.java
@@ -15,12 +15,14 @@ public class OptionsParser {
     private String m_warehouse;
     private String m_outputFormat;
     private String m_tableFormat;
+    private String m_snapshotId;
 
     public OptionsParser() {
         m_uri = null;
         m_warehouse = null;
         m_outputFormat = "console";
         m_tableFormat = "iceberg";
+        m_snapshotId = null;
     }
     
     /**
@@ -53,6 +55,7 @@ public class OptionsParser {
         options.addOption(Option.builder("w").longOpt("warehouse").argName("value").hasArg().desc("Table location").build());
         options.addOption(Option.builder("o").longOpt("output").argName("console|csv|json").hasArg().desc("Show output in this format").build());
         options.addOption(Option.builder().longOpt("format").argName("iceberg|hive").hasArg().desc("The format of the table we want to display").build());
+        options.addOption(Option.builder().longOpt("snapshot").argName("snapshot ID").hasArg().desc("Snapshot ID to use").build());
         
         CommandLineParser parser = new DefaultParser();
 
@@ -75,6 +78,9 @@ public class OptionsParser {
                 // Get table format
                 if (cmd.hasOption("format"))
                     m_tableFormat = cmd.getOptionValue("format");
+                // Get snapshot id
+                if (cmd.hasOption("snapshot"))
+                    m_snapshotId = cmd.getOptionValue("snapshot");
             }
          
         } catch (ParseException exp) {
@@ -88,5 +94,5 @@ public class OptionsParser {
     public String warehouse() { return m_warehouse; }
     public String tableFormat() { return m_tableFormat; }
     public String outputFormat() { return m_outputFormat; }
-    
+    public String snapshotId() { return m_snapshotId; }
 }

--- a/tools/java-iceberg-cli/src/main/java/iceberg/cli/Parser.java
+++ b/tools/java-iceberg-cli/src/main/java/iceberg/cli/Parser.java
@@ -50,6 +50,7 @@ public class Parser {
     public String warehouse() { return optParser.warehouse(); }
     public String tableFormat() { return optParser.tableFormat(); }
     public String outputFormat() { return optParser.outputFormat(); }
+    public String snapshotId() { return optParser.snapshotId(); }
 
     // Get arguments
     public String outputFile() { return cmdParser.outputFile(); }

--- a/tools/java-iceberg-cli/src/main/java/iceberg/utils/PrintUtils.java
+++ b/tools/java-iceberg-cli/src/main/java/iceberg/utils/PrintUtils.java
@@ -128,7 +128,7 @@ public class PrintUtils {
         String outputString = null;
         
         String planFiles = output.tableFiles(metaConn.getPlanFiles());
-        long snapshotId = metaConn.currentSnapshotId();
+        Long snapshotId = metaConn.currentSnapshotId();
         switch (format) {
             case "json":
                 JSONObject filesAsJson = new JSONObject(planFiles);
@@ -167,7 +167,7 @@ public class PrintUtils {
         String outputString = null;
         
         String schema = output.tableSchema(metaConn.getTableSchema());
-        long snapshotId = metaConn.currentSnapshotId();
+        Long snapshotId = metaConn.currentSnapshotId();
         switch (format) {
             case "json":
                 JSONObject schemaAsJson = new JSONObject(schema);

--- a/tools/java-iceberg-cli/src/main/java/iceberg/utils/PrintUtils.java
+++ b/tools/java-iceberg-cli/src/main/java/iceberg/utils/PrintUtils.java
@@ -128,7 +128,7 @@ public class PrintUtils {
         String outputString = null;
         
         String planFiles = output.tableFiles(metaConn.getPlanFiles());
-        long snapshotId = metaConn.getCurrentSnapshot().snapshotId();
+        long snapshotId = metaConn.currentSnapshotId();
         switch (format) {
             case "json":
                 JSONObject filesAsJson = new JSONObject(planFiles);
@@ -167,7 +167,7 @@ public class PrintUtils {
         String outputString = null;
         
         String schema = output.tableSchema(metaConn.getTableSchema());
-        long snapshotId = metaConn.getCurrentSnapshot().snapshotId();
+        long snapshotId = metaConn.currentSnapshotId();
         switch (format) {
             case "json":
                 JSONObject schemaAsJson = new JSONObject(schema);

--- a/tools/java-iceberg-cli/src/main/java/iceberg/utils/PrintUtils.java
+++ b/tools/java-iceberg-cli/src/main/java/iceberg/utils/PrintUtils.java
@@ -128,7 +128,7 @@ public class PrintUtils {
         String outputString = null;
         
         String planFiles = output.tableFiles(metaConn.getPlanFiles());
-        Long snapshotId = metaConn.currentSnapshotId();
+        Long snapshotId = metaConn.getCurrentSnapshotId();
         switch (format) {
             case "json":
                 JSONObject filesAsJson = new JSONObject(planFiles);
@@ -167,7 +167,7 @@ public class PrintUtils {
         String outputString = null;
         
         String schema = output.tableSchema(metaConn.getTableSchema());
-        Long snapshotId = metaConn.currentSnapshotId();
+        Long snapshotId = metaConn.getCurrentSnapshotId();
         switch (format) {
             case "json":
                 JSONObject schemaAsJson = new JSONObject(schema);


### PR DESCRIPTION
GitHub issue link: https://github.com/IBM/java-iceberg-toolkit/issues/11

Problem: Currently, the toolkit fetches table info based on the latest snapshot.

Solution: Allow users to pass a snapshot ID which will be used to retrieve information.

Testing:

- [x] Unit tests 
- [ ] Additional tests (add results below)

Documentation:
- [ ] Documentation not needed
- [x] Updated README file
- [ ] Documentation prepared (provide link below)
