### PR TITLE
Enhancement to Catalog Config

### DIFF
--- a/tools/java-iceberg-cli/src/main/java/iceberg_cli/catalog/Catalogs.java
+++ b/tools/java-iceberg-cli/src/main/java/iceberg_cli/catalog/Catalogs.java
@@ -22,9 +22,12 @@ public class Catalogs {
         return catalogs;
     }
 
-    public CustomCatalog getCatalog(String catalogName) {
+    public CustomCatalog getCatalog(String catalogName, String metastoreUri) {
+        if (catalogName == null || metastoreUri == null)
+            return null;
+        
         for (CustomCatalog catalog : catalogs) {
-            if (catalog.getName().equalsIgnoreCase(catalogName)) {
+            if (catalog.getName().equalsIgnoreCase(catalogName) && catalog.getMetastoreUri().equalsIgnoreCase(metastoreUri)) {
                 return catalog;
             }
         }

--- a/tools/java-iceberg-cli/src/main/java/iceberg_cli/catalog/CustomCatalog.java
+++ b/tools/java-iceberg-cli/src/main/java/iceberg_cli/catalog/CustomCatalog.java
@@ -35,6 +35,7 @@ public class CustomCatalog {
             this.type = type;
         }
     }
+    private String metastoreUri;
     private Map<String, String> properties;
     private Configuration conf;
 
@@ -58,17 +59,27 @@ public class CustomCatalog {
         this.properties = new HashMap<String, String>();
         this.conf = new HiveConf();
     }
-
-    public CustomCatalog(String name, CatalogType type, Map<String, String> props) {
+    
+    public CustomCatalog(String name, CatalogType type, String metastoreUri) {
         this.name = name;
         this.type = type;
+        this.metastoreUri = metastoreUri;
+        this.properties = new HashMap<String, String>();
+        this.conf = new HiveConf();
+    }
+
+    public CustomCatalog(String name, CatalogType type, String metastoreUri, Map<String, String> props) {
+        this.name = name;
+        this.type = type;
+        this.metastoreUri = metastoreUri;
         this.properties = props;
         this.conf = new HiveConf();
     }
 
-    public CustomCatalog(String name, CatalogType type, Map<String, String> props, HiveConf conf) {
+    public CustomCatalog(String name, CatalogType type, String metastoreUri, Map<String, String> props, HiveConf conf) {
         this.name = name;
         this.type = type;
+        this.metastoreUri = metastoreUri;
         this.properties = props;
         this.conf = conf;
     }
@@ -79,6 +90,10 @@ public class CustomCatalog {
 
     public CatalogType getType() {
         return type;
+    }
+    
+    public String getMetastoreUri() {
+        return metastoreUri;
     }
 
     @JsonIgnore
@@ -110,6 +125,10 @@ public class CustomCatalog {
 
     public void setType(CatalogType type) {
         this.type = type;
+    }
+    
+    public void setMetastoreUri(String metastoreUri) {
+        this.metastoreUri = metastoreUri;
     }
 
     @JsonIgnore
@@ -157,6 +176,8 @@ public class CustomCatalog {
         sb.append("Name: " + name);
         sb.append("\n");
         sb.append("Type: " + type);
+        sb.append("\n");
+        sb.append("Metastore Uri: " + metastoreUri);
         sb.append("\n");
         sb.append("Properties: " + properties);
         sb.append("\n");

--- a/tools/java-iceberg-cli/src/main/java/iceberg_cli/catalog/CustomCatalogDeserializer.java
+++ b/tools/java-iceberg-cli/src/main/java/iceberg_cli/catalog/CustomCatalogDeserializer.java
@@ -31,6 +31,7 @@ public class CustomCatalogDeserializer extends StdDeserializer<CustomCatalog> {
         JsonNode node = p.getCodec().readTree(p);
         String name = node.get("name").asText();
         CustomCatalog.CatalogType type = CustomCatalog.CatalogType.valueOf(node.get("type").asText());
+        String metastoreUri = node.get("metastoreUri").asText();
         ObjectMapper mapper = new ObjectMapper();
         Map<String, String> properties = mapper.convertValue(node.get("properties"), new TypeReference<Map<String, String>>(){});
         Map<String, String> conf = mapper.convertValue(node.get("conf"), new TypeReference<Map<String, String>>(){});
@@ -39,7 +40,7 @@ public class CustomCatalogDeserializer extends StdDeserializer<CustomCatalog> {
             hiveConf.set(entry.getKey(), entry.getValue());
         }
         
-        return new CustomCatalog(name, type, properties, hiveConf);
+        return new CustomCatalog(name, type, metastoreUri, properties, hiveConf);
     }
 
 }

--- a/tools/java-iceberg-cli/src/main/java/iceberg_cli/utils/CatalogUtils.java
+++ b/tools/java-iceberg-cli/src/main/java/iceberg_cli/utils/CatalogUtils.java
@@ -33,7 +33,7 @@ public class CatalogUtils {
             String namespace, String table, Credentials creds) throws Exception {
         MetastoreConnector conn = null;
         // Load catalog information
-        CustomCatalog catalog = new ConfigLoader().init(catalogName, uri, warehouse);
+        CustomCatalog catalog = new ConfigLoader().init(catalogName, uri, warehouse, creds);
         
         // Auto detect format
         if (format == null) {

--- a/tools/java-iceberg-cli/src/test/java/iceberg_cli/FunctionalTest.java
+++ b/tools/java-iceberg-cli/src/test/java/iceberg_cli/FunctionalTest.java
@@ -63,7 +63,7 @@ class FunctionalTest {
             // Create a dummy credentials object instead which will be populated using env variables
             creds = new AwsCredentials(new JSONObject());
             // Load catalog configuration
-            catalog = new ConfigLoader().init("default", uri, warehouse);
+            catalog = new ConfigLoader().init("default", uri, warehouse, creds);
             // Initialize connector using a dummy credentials object
             metaConn = new IcebergConnector(catalog, namespace, tableName, creds);
             if (warehouse == null) {

--- a/tools/java-iceberg-cli/src/test/java/iceberg_cli/TestAlterTable.java
+++ b/tools/java-iceberg-cli/src/test/java/iceberg_cli/TestAlterTable.java
@@ -51,7 +51,7 @@ class TestAlterTable {
         CustomCatalog catalog = null;
         try {
             // Load catalog configuration
-            catalog = new ConfigLoader().init("default", uri, warehouse);
+            catalog = new ConfigLoader().init("default", uri, warehouse, creds);
         } catch (Exception e) {
             System.err.println("ERROR: " + e.getMessage());
         }


### PR DESCRIPTION
GitHub issue link: #27 

Problem: Enhancement to provide ability to connect to multiple metastores and add an alternate directory, apart from the user home directory to search for the config file

Solution: 
1. Include the metastore URI and only apply these settings when connecting to that metastore, so load config values only if the metastore URI matches.
2. Check for yaml file in ICEBERG_CONFIG and fall back to user home directory

Testing:

- [ ] Unit tests 
- [ ] Additional tests (add results below)

Documentation:
- [ ] Documentation not needed
- [ ] Updated README file
- [ ] Documentation prepared (provide link below)
