### PR TITLE
Add action for retrieving table record count

### DIFF
--- a/tools/java-iceberg-cli/src/main/java/iceberg_cli/IcebergApplication.java
+++ b/tools/java-iceberg-cli/src/main/java/iceberg_cli/IcebergApplication.java
@@ -121,6 +121,9 @@ public class IcebergApplication {
         case "metadata":
             output = printUtils.printTableMetadata();
             break;
+        case "recordcount":
+            output = printUtils.printRecordCount();
+            break;
         case "tasks":
             output = printUtils.printTasks();
             break;

--- a/tools/java-iceberg-cli/src/main/java/iceberg_cli/MetastoreConnector.java
+++ b/tools/java-iceberg-cli/src/main/java/iceberg_cli/MetastoreConnector.java
@@ -35,6 +35,8 @@ import org.apache.iceberg.PartitionField;
 public abstract class MetastoreConnector 
 {
     protected Long m_snapshotId = null;
+    protected Long fileRecordCount = 0L;
+    protected Long taskRecordCount = 0L;
 
     public MetastoreConnector(CustomCatalog catalog, String namespace, String tableName, Credentials creds) {
     }
@@ -95,6 +97,14 @@ public abstract class MetastoreConnector
 
     public void setSnapshotId(Long snapshotId) {
         this.m_snapshotId = snapshotId;
+    }
+    
+    public Long getFileRecordCount() {
+        return fileRecordCount;
+    }
+
+    public Long getTaskRecordCount() {
+        return taskRecordCount;
     }
     
     @SuppressWarnings("serial")

--- a/tools/java-iceberg-cli/src/main/java/iceberg_cli/cli/OptionsParser.java
+++ b/tools/java-iceberg-cli/src/main/java/iceberg_cli/cli/OptionsParser.java
@@ -60,7 +60,7 @@ public class OptionsParser {
         options.addOption(Option.builder("w").longOpt("warehouse").argName("value").hasArg().desc("Table location").build());
         options.addOption(Option.builder("o").longOpt("output").argName("console|csv|json").hasArg().desc("Show output in this format").build());
         options.addOption(Option.builder().longOpt("catalog").argName("value").hasArg().desc("Read properties for this catalog from the config file").build());
-        options.addOption(Option.builder().longOpt("format").argName("iceberg|hive").hasArg().desc("The format of the table we want to display").build());
+        options.addOption(Option.builder("m").longOpt("format").argName("iceberg|hive").hasArg().desc("The format of the table we want to display").build());
         options.addOption(Option.builder().longOpt("snapshot").argName("snapshot ID").hasArg().desc("Snapshot ID to use").build());
         
         CommandLineParser parser = new DefaultParser();

--- a/tools/java-iceberg-cli/src/main/java/iceberg_cli/cli/Parser.java
+++ b/tools/java-iceberg-cli/src/main/java/iceberg_cli/cli/Parser.java
@@ -119,6 +119,11 @@ public class Parser {
         metadata.addArgument("identifier", "Table identifier", true);
         m_commands.put("metadata", metadata);
         
+        Command recordcount = new Command("recordcount", "Get total number of records in a table");
+        recordcount.addOption("--help", "Show this help message and exit");
+        recordcount.addArgument("identifier", "Table identifier", true);
+        m_commands.put("recordcount", recordcount);
+        
         Command read = new Command("read", "Read from a table");
         read.addOption("--help", "Show this help message and exit");
         read.addArgument("identifier", "Table identifier", true);

--- a/tools/java-iceberg-cli/src/main/java/iceberg_cli/utils/PrintUtils.java
+++ b/tools/java-iceberg-cli/src/main/java/iceberg_cli/utils/PrintUtils.java
@@ -58,18 +58,29 @@ public class PrintUtils {
     }
     
     /**
+     * Get total record count from MetastoreConnector and return to the user is the given format
+     * @throws Exception 
+     */
+    public String printRecordCount() throws Exception {
+        Long totalEstimatedRecords = metaConn.getFileRecordCount();
+        
+        return output.tableRecordCount(totalEstimatedRecords);
+    }
+    
+    /**
      * Get table details from MetastoreConnector and output to the user is the given format
      * @throws Exception 
      */
     public String printTableDetails() throws Exception {
         Map<Integer, List<Map<String, String>>> planFileTasks = metaConn.getPlanFiles();
+        Long totalEstimatedRecords = metaConn.getFileRecordCount();
         Snapshot snapshot = metaConn.getCurrentSnapshot();
         Schema targetSchema = metaConn.getTableSchema();
         String tableLocation = metaConn.getTableLocation();
         String dataLocation = metaConn.getTableDataLocation();
         String type = metaConn.getTableType();
         
-        return output.tableDetails(planFileTasks, snapshot, targetSchema, tableLocation, dataLocation, type);
+        return output.tableDetails(planFileTasks, snapshot, targetSchema, tableLocation, dataLocation, type, totalEstimatedRecords);
     }
     
     /**
@@ -142,7 +153,9 @@ public class PrintUtils {
     public String printFiles() throws Exception {
         String outputString = null;
         
-        String planFiles = output.tableFiles(metaConn.getPlanFiles());
+        Map<Integer, List<Map<String, String>>> taskMapList = metaConn.getPlanFiles();
+        Long totalEstimatedRecords = metaConn.getFileRecordCount();
+        String planFiles = output.tableFiles(taskMapList, totalEstimatedRecords);
         Long snapshotId = metaConn.getCurrentSnapshotId();
         switch (format) {
             case "json":
@@ -165,7 +178,9 @@ public class PrintUtils {
     public String printTasks() throws Exception {
         String outputString = null;
         
-        String planFiles = output.tableFiles(metaConn.getPlanTasks());
+        Map<Integer, List<Map<String, String>>> taskMapList = metaConn.getPlanTasks();
+        Long totalEstimatedRecords = metaConn.getTaskRecordCount();
+        String planFiles = output.tableFiles(taskMapList, totalEstimatedRecords);
         Long snapshotId = metaConn.getCurrentSnapshotId();
         switch (format) {
             case "json":

--- a/tools/java-iceberg-cli/src/main/java/iceberg_cli/utils/output/CsvOutput.java
+++ b/tools/java-iceberg-cli/src/main/java/iceberg_cli/utils/output/CsvOutput.java
@@ -14,6 +14,10 @@ import org.apache.iceberg.Snapshot;
 import iceberg_cli.utils.DataConversion;
 
 public class CsvOutput extends Output {
+    
+    public CsvOutput() {
+        this.delimiter = ',';
+    }
 
     @Override
     public String listTables(List<String> tables) throws Exception {
@@ -44,34 +48,6 @@ public class CsvOutput extends Output {
                 builder.append("\n");
             }
         }
-        return builder.toString();
-    }
-
-    @Override
-    public String tableFiles(Map<Integer, List<Map<String, String>>> planFileTasks) throws Exception {
-        StringBuilder builder = new StringBuilder();
-        
-        // Add data files
-        char delim = ',';
-        if (planFileTasks != null) {
-            builder.append(String.format("TOTAL TASKS : %d\n", planFileTasks.size()));
-            for (Map.Entry<Integer, List<Map<String, String>>> entry : planFileTasks.entrySet()) {
-                builder.append(String.format("TOTAL FILES IN TASK %d : %d\n", entry.getKey(),entry.getValue().size()));
-                for (Map<String, String> task : entry.getValue()) {
-                    String taskInfo = String.format("%s%c%s%c%s%c%s%c%s%c%s%c%s",
-                                                    task.get("content"), delim,
-                                                    task.get("file_path"), delim,
-                                                    task.get("file_format"), delim,
-                                                    task.get("start"), delim,
-                                                    task.get("length"), delim,
-                                                    task.get("spec"), delim,
-                                                    task.get("residual")
-                                                    );
-                    builder.append(String.format("%s\n", taskInfo));
-                }
-            }
-        }
-        
         return builder.toString();
     }
 

--- a/tools/java-iceberg-cli/src/main/java/iceberg_cli/utils/output/JsonOutput.java
+++ b/tools/java-iceberg-cli/src/main/java/iceberg_cli/utils/output/JsonOutput.java
@@ -33,13 +33,21 @@ public class JsonOutput extends Output{
                 
         return tableMetadata.toString();
     }
+    
+    @Override
+    public String tableRecordCount(Long totalEstimatedRecords) throws Exception {
+        JSONObject recordCount = new JSONObject();
+        recordCount.put("record_count", totalEstimatedRecords);
+        
+        return recordCount.toString();
+    }
 
     @Override
     public String tableDetails(Map<Integer, List<Map<String, String>>> planFileTasks, Snapshot snapshot,
-            Schema schema, String tableLocation, String dataLocation, String type) throws Exception {
+            Schema schema, String tableLocation, String dataLocation, String type, Long totalEstimatedRecords) throws Exception {
         JSONObject tableDetails = new JSONObject();
         
-        JSONObject dataFiles = new JSONObject(tableFiles(planFileTasks));
+        JSONObject dataFiles = new JSONObject(tableFiles(planFileTasks, totalEstimatedRecords));
         JSONObject schemaObject = new JSONObject(tableSchema(schema));
         JSONObject currentSnapshot = new JSONObject(currentSnapshot(snapshot));
         tableDetails.put("files", dataFiles);
@@ -95,12 +103,13 @@ public class JsonOutput extends Output{
     }
 
     @Override
-    public String tableFiles(Map<Integer, List<Map<String, String>>> planFileTasks) throws Exception {
+    public String tableFiles(Map<Integer, List<Map<String, String>>> planFileTasks, Long totalEstimatedRecords) throws Exception {
         if (planFileTasks == null) {
             return null;
         }
         
         JSONObject planFilesJsonObject = new JSONObject();
+        planFilesJsonObject.put("total_estimated_records", totalEstimatedRecords);
         for (Map.Entry<Integer, List<Map<String, String>>> entry : planFileTasks.entrySet()) {
             JSONArray tasksArray = new JSONArray();
             for (Map<String, String> task : entry.getValue()) {
@@ -108,6 +117,7 @@ public class JsonOutput extends Output{
                 taskobj.put("content", task.get("content"));
                 taskobj.put("file_path", task.get("file_path"));
                 taskobj.put("file_format", task.get("file_format"));
+                taskobj.put("record_count", task.get("record_count"));
                 taskobj.put("start", task.get("start"));
                 taskobj.put("length", task.get("length"));
                 taskobj.put("spec", task.get("spec"));

--- a/tools/java-iceberg-cli/src/main/java/iceberg_cli/utils/output/Output.java
+++ b/tools/java-iceberg-cli/src/main/java/iceberg_cli/utils/output/Output.java
@@ -13,6 +13,7 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.Snapshot;
 
 public class Output {
+    protected char delimiter = ' ';
     
     public String tableMetadata(Snapshot snapshot, Schema schema, String tableLocation, String dataLocation, String type) throws Exception {
         StringBuilder builder = new StringBuilder();
@@ -30,10 +31,18 @@ public class Output {
         return builder.toString();
     }
     
-    public String tableDetails(Map<Integer, List<Map<String, String>>> planFileTasks, Snapshot snapshot,
-            Schema schema, String tableLocation, String dataLocation, String type) throws Exception {
+    public String tableRecordCount(Long totalEstimatedRecords) throws Exception {
         StringBuilder builder = new StringBuilder();
-        builder.append(tableFiles(planFileTasks));
+        builder.append("TOTAL RECORDS\n");
+        builder.append(totalEstimatedRecords);
+        
+        return builder.toString();
+    }
+    
+    public String tableDetails(Map<Integer, List<Map<String, String>>> planFileTasks, Snapshot snapshot,
+            Schema schema, String tableLocation, String dataLocation, String type, Long totalEstimatedRecords) throws Exception {
+        StringBuilder builder = new StringBuilder();
+        builder.append(tableFiles(planFileTasks, totalEstimatedRecords));
         builder.append("SNAPSHOT\n");
         builder.append(currentSnapshot(snapshot));
         builder.append("\nSCHEMA\n");
@@ -94,23 +103,24 @@ public class Output {
         return builder.toString();
     }
     
-    public String tableFiles(Map<Integer, List<Map<String, String>>> planFileTasks) throws Exception {
+    public String tableFiles(Map<Integer, List<Map<String, String>>> planFileTasks, Long totalEstimatedRecords) throws Exception {
         StringBuilder builder = new StringBuilder();
         
         // Add data files
-        char delim = ' ';
         if (planFileTasks != null) {
+            builder.append(String.format("TOTAL ESTIMATED RECORDS : %d\n", totalEstimatedRecords));
             builder.append(String.format("TOTAL TASKS : %d\n", planFileTasks.size()));
             for (Map.Entry<Integer, List<Map<String, String>>> entry : planFileTasks.entrySet()) {
                 builder.append(String.format("TOTAL FILES IN TASK %d : %d\n", entry.getKey(),entry.getValue().size()));
                 for (Map<String, String> task : entry.getValue()) {
-                    String taskInfo = String.format("%s%c%s%c%s%c%s%c%s%c%s%c%s",
-                                                    task.get("content"), delim,
-                                                    task.get("file_path"), delim,
-                                                    task.get("file_format"), delim,
-                                                    task.get("start"), delim,
-                                                    task.get("length"), delim,
-                                                    task.get("spec"), delim,
+                    String taskInfo = String.format("%s%c%s%c%s%c%s%c%s%c%s%c%s%c%s",
+                                                    task.get("content"), this.delimiter,
+                                                    task.get("file_path"), this.delimiter,
+                                                    task.get("file_format"), this.delimiter,
+                                                    task.get("record_count"), this.delimiter,
+                                                    task.get("start"), this.delimiter,
+                                                    task.get("length"), this.delimiter,
+                                                    task.get("spec"), this.delimiter,
                                                     task.get("residual")
                                                     );
                     builder.append(String.format("%s\n", taskInfo));

--- a/tools/java-iceberg-cli/src/test/java/iceberg_cli/FunctionalTest.java
+++ b/tools/java-iceberg-cli/src/test/java/iceberg_cli/FunctionalTest.java
@@ -43,7 +43,7 @@ class FunctionalTest {
     static MetastoreConnector metaConn;
     static String namespace;
     static String tableName;
-    static Integer total_tests = 7;
+    static Integer total_tests = 9;
     static Integer passed_tests = 0;
     static ArrayList <String> failed_tests = new ArrayList<String>();
     
@@ -171,9 +171,27 @@ class FunctionalTest {
             throw new ServletException("Error: " + t.getMessage(), t);
         }
     }
-
+    
     @Test
     @Order(6)
+    @DisplayName("Test the functionality of recordcount table")
+    void recordcount() throws ServletException {
+        try {
+            Long expected = 1L;
+            
+            System.out.println("Running test 6...");
+            Long actual = metaConn.getFileRecordCount();
+            Assertions.assertEquals(expected, actual);    
+            System.out.println("Test 6 completed");
+            passed_tests += 1;
+        } catch (Throwable t) {
+            failed_tests.add("recordcount");
+            throw new ServletException("Error: " + t.getMessage(), t);
+        }
+    }
+
+    @Test
+    @Order(7)
     @DisplayName("Test the functionality of rewrite files")
     void rewritefiles() throws ServletException {
         try {
@@ -181,7 +199,7 @@ class FunctionalTest {
             MetastoreConnector metaConnDup = new IcebergConnector(catalog, namespace, (tableName + "Dup"), creds);
             Schema schema = SchemaParser.fromJson("{\"type\":\"struct\",\"schema-id\":0,\"fields\":[{\"id\":1,\"name\":\"ID\",\"required\":true,\"type\":\"int\"},{\"id\":2,\"name\":\"Name\",\"required\":true,\"type\":\"string\"},{\"id\":3,\"name\":\"Price\",\"required\":true,\"type\":\"double\"},{\"id\":4,\"name\":\"Purchase_date\",\"required\":true,\"type\":\"timestamp\"}]}");
         
-            System.out.println("Running test 8...");
+            System.out.println("Running test 7...");
             String record = "{\"records\":[{\"ID\":1,\"Name\":\"Testing\",\"Price\": 1000,\"Purchase_date\":\"2022-11-09T12:13:54.480\"}]}";
             String dataFiles = metaConn.writeTable(record, null);
             boolean status = metaConn.commitTable(dataFiles);
@@ -196,7 +214,7 @@ class FunctionalTest {
             // Clean up rewritten table
             status = metaConnDup.dropTable();
             Assertions.assertEquals(true, status);
-            System.out.println("Test 8 completed");
+            System.out.println("Test 7 completed");
             passed_tests += 1;
         } catch (Throwable t) {
             failed_tests.add("rewritefiles");
@@ -205,14 +223,14 @@ class FunctionalTest {
     }
     
     @Test
-    @Order(7)
+    @Order(8)
     @DisplayName("Test the functionality of drop table")
     void droptable() throws ServletException {
         try {
-            System.out.println("Running test 6...");
+            System.out.println("Running test 8...");
             boolean status = metaConn.dropTable();
             Assertions.assertEquals(true, status);
-            System.out.println("Test 6 completed");
+            System.out.println("Test 8 completed");
             passed_tests += 1;
         } catch (Throwable t) {
             failed_tests.add("droptable");
@@ -221,16 +239,16 @@ class FunctionalTest {
     }    
     
     @Test
-    @Order(8)
+    @Order(9)
     @DisplayName("Test the functionality of drop namespace")
     void dropnamespace() throws ServletException {
         try {
             Namespace nmspc = Namespace.of(namespace);
             
-            System.out.println("Running test 7...");
+            System.out.println("Running test 9...");
             boolean status = metaConn.dropNamespace(nmspc);
             Assertions.assertEquals(true, status);
-            System.out.println("Test 7 completed");
+            System.out.println("Test 9 completed");
             passed_tests += 1;
         } catch (Throwable t) {
             failed_tests.add("dropnamespace");

--- a/tools/java-iceberg-cli/src/test/java/iceberg_cli/TestUserInputConsole.java
+++ b/tools/java-iceberg-cli/src/test/java/iceberg_cli/TestUserInputConsole.java
@@ -141,7 +141,7 @@ class TestUserInputConsole {
         args[3] = namespace + "." + tablename;
         
         try {
-            System.out.println("Running test 6...");
+            System.out.println("Running test 5...");
             String out = new IcebergApplication().processRequest(args);
             Assertions.assertEquals("TOTAL RECORDS\n" + 1, out);
             System.out.println("Test 5 completed");

--- a/tools/java-iceberg-cli/src/test/java/iceberg_cli/TestUserInputConsole.java
+++ b/tools/java-iceberg-cli/src/test/java/iceberg_cli/TestUserInputConsole.java
@@ -20,7 +20,7 @@ class TestUserInputConsole {
     static String warehouse;
     static String namespace;
     static String tablename;
-    static Integer total_tests = 6;
+    static Integer total_tests = 7;
     static Integer passed_tests = 0;
     static ArrayList <String> failed_tests = new ArrayList<String>();
     
@@ -132,6 +132,29 @@ class TestUserInputConsole {
     
     @Test
     @Order(5)
+    @DisplayName("Test the functionality of recordcount action")
+    void recordcount() throws ServletException {
+        String[] args = new String[4];
+        args[0] = "-u";
+        args[1] = uri;
+        args[2] = "recordcount";
+        args[3] = namespace + "." + tablename;
+        
+        try {
+            System.out.println("Running test 6...");
+            String out = new IcebergApplication().processRequest(args);
+            Assertions.assertEquals("TOTAL RECORDS\n" + 1, out);
+            System.out.println("Test 5 completed");
+            passed_tests += 1;
+        } catch (Throwable t) {
+            failed_tests.add("listtables");
+            throw new ServletException("Error: " + t.getMessage(), t);
+        }
+        
+    }
+    
+    @Test
+    @Order(6)
     @DisplayName("Test the functionality of drop action")
     void droptable() throws ServletException {
         String[] args = new String[4];
@@ -141,10 +164,10 @@ class TestUserInputConsole {
         args[3] = namespace + "." + tablename;
         
         try {
-            System.out.println("Running test 5...");
+            System.out.println("Running test 6...");
             String out = new IcebergApplication().processRequest(args);
             Assertions.assertEquals("Operation successful? true", out);
-            System.out.println("Test 5 completed");
+            System.out.println("Test 6 completed");
             passed_tests += 1;
         } catch (Throwable t) {
             failed_tests.add("droptable");
@@ -154,7 +177,7 @@ class TestUserInputConsole {
     }
     
     @Test
-    @Order(6)
+    @Order(7)
     @DisplayName("Test the functionality of dropnamespace action")
     void dropnamespace() throws ServletException {
         String[] args = new String[4];
@@ -164,10 +187,10 @@ class TestUserInputConsole {
         args[3] = namespace;
                   
         try {
-            System.out.println("Running test 6...");
+            System.out.println("Running test 7...");
             String out = new IcebergApplication().processRequest(args);
             Assertions.assertEquals("Operation successful? true", out);
-            System.out.println("Test 6 completed");
+            System.out.println("Test 7 completed");
             passed_tests += 1;
         } catch (Throwable t) {
             failed_tests.add("dropnamespace");


### PR DESCRIPTION
GitHub issue link: https://github.com/IBM/java-iceberg-toolkit/issues/30

Problem: Need a way to table record count. 

Solution:

- Add recordcount command to retrieve number of records.
- Get table record count when listing files and listing tasks.

Testing:

- [x] Unit tests 
- [ ] Additional tests (add results below)

Documentation:
- [ ] Documentation not needed
- [ ] Updated README file
- [ ] Documentation prepared (provide link below)
