### PR TITLE
Update maven to 3.9.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,10 @@ RUN mkdir -p /opt/java \
 # Install Maven
 RUN mkdir -p /opt/maven \
     && cd /opt/maven \
-    && wget https://dlcdn.apache.org/maven/maven-3/3.9.2/binaries/apache-maven-3.9.2-bin.tar.gz \
-    && tar xvzf apache-maven-3.9.2-bin.tar.gz \
-    && ln -s /opt/maven/apache-maven-3.9.2/bin/mvn /usr/bin/mvn \
-    && rm -f apache-maven-3.9.2-bin.tar.gz
+    && wget https://dlcdn.apache.org/maven/maven-3/3.9.3/binaries/apache-maven-3.9.3-bin.tar.gz \
+    && tar xvzf apache-maven-3.9.3-bin.tar.gz \
+    && ln -s /opt/maven/apache-maven-3.9.3/bin/mvn /usr/bin/mvn \
+    && rm -f apache-maven-3.9.3-bin.tar.gz
 
 # Install java-iceberg-cli
 COPY tools/java-iceberg-cli /home/java-iceberg-cli

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,10 @@ RUN mkdir -p /opt/java \
 # Install Maven
 RUN mkdir -p /opt/maven \
     && cd /opt/maven \
-    && wget https://dlcdn.apache.org/maven/maven-3/3.9.3/binaries/apache-maven-3.9.3-bin.tar.gz \
-    && tar xvzf apache-maven-3.9.3-bin.tar.gz \
-    && ln -s /opt/maven/apache-maven-3.9.3/bin/mvn /usr/bin/mvn \
-    && rm -f apache-maven-3.9.3-bin.tar.gz
+    && wget https://dlcdn.apache.org/maven/maven-3/3.9.4/binaries/apache-maven-3.9.4-bin.tar.gz \
+    && tar xvzf apache-maven-3.9.4-bin.tar.gz \
+    && ln -s /opt/maven/apache-maven-3.9.4/bin/mvn /usr/bin/mvn \
+    && rm -f apache-maven-3.9.4-bin.tar.gz
 
 # Install java-iceberg-cli
 COPY tools/java-iceberg-cli /home/java-iceberg-cli


### PR DESCRIPTION
GitHub issue link: https://github.com/IBM/java-iceberg-toolkit/issues/34

Problem:
In Dockerfile update maven version to 3.9.3 - build is failing otherwise

Solution:

update maven to 3.9.4 

Testing:

```
[INFO] Dependency-reduced POM written at: /home/java-iceberg-cli/dependency-reduced-pom.xml
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  02:56 min
[INFO] Finished at: 2023-08-03T16:15:50Z
[INFO] ------------------------------------------------------------------------
--> 48ce7cc3b65
STEP 7/8: RUN rm -rf /tmp/*
--> 940d0bc86db
STEP 8/8: ENTRYPOINT ["tail", "-f", "/dev/null"]
COMMIT java-iceberg-cli:latest
--> 00b1d935cfd
Successfully tagged localhost/java-iceberg-cli:latest


```

- [ ] Unit tests 
- [ ] Additional tests (add results below)

Documentation:
- [X] Documentation not needed
- [ ] Updated README file
- [ ] Documentation prepared (provide link below)
