### PR TITLE
Add dependencies for zookeeper, avro, logback-* jars in pom.xml

### DIFF
--- a/tools/java-iceberg-cli/pom.xml
+++ b/tools/java-iceberg-cli/pom.xml
@@ -244,11 +244,11 @@
                 <groupId>org.apache.parquet</groupId>
                 <artifactId>parquet-avro</artifactId>
                 <version>1.12.3</version>
+            </dependency>
             <dependency>
                 <groupId>org.apache.avro</groupId>
                 <artifactId>avro</artifactId>
                 <version>1.11.3</version>
-            </dependency>
             </dependency>
             <dependency>
                 <groupId>org.apache.hadoop</groupId>

--- a/tools/java-iceberg-cli/pom.xml
+++ b/tools/java-iceberg-cli/pom.xml
@@ -26,6 +26,11 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>org.apache.zookeeper</groupId>
+                <artifactId>zookeeper</artifactId>
+                <version>3.9.1</version>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.calcite.avatica</groupId>
                 <artifactId>avatica</artifactId>
                 <version>${org.apache.calcite.avatica.version}</version>

--- a/tools/java-iceberg-cli/pom.xml
+++ b/tools/java-iceberg-cli/pom.xml
@@ -26,6 +26,11 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>org.apache.avro</groupId>
+                <artifactId>avro</artifactId>
+                <version>1.11.3</version>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.zookeeper</groupId>
                 <artifactId>zookeeper</artifactId>
                 <version>3.9.1</version>

--- a/tools/java-iceberg-cli/pom.xml
+++ b/tools/java-iceberg-cli/pom.xml
@@ -26,6 +26,11 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-core</artifactId>
+                <version>1.4.12</version>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.zookeeper</groupId>
                 <artifactId>zookeeper</artifactId>
                 <version>3.9.1</version>

--- a/tools/java-iceberg-cli/pom.xml
+++ b/tools/java-iceberg-cli/pom.xml
@@ -17,6 +17,7 @@
         <org.apache.iceberg.version>1.1.0</org.apache.iceberg.version>
         <org.apache.hadoop.version>3.3.5</org.apache.hadoop.version>
         <org.apache.hive.version>4.0.0-alpha-2</org.apache.hive.version>
+        <ch.qos.logback.version>1.4.12</ch.qos.logback.version>
         <software.amazon.awssdk.version>2.17.272</software.amazon.awssdk.version>
         <org.junit.jupiter.version>5.8.1</org.junit.jupiter.version>
         <maven.compiler.source>17</maven.compiler.source>
@@ -28,12 +29,12 @@
             <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-core</artifactId>
-                <version>1.4.12</version>
+                <version>${ch.qos.logback.version}</version>
             </dependency>
             <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-classic</artifactId>
-                <version>1.4.12</version>
+                <version>${ch.qos.logback.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.zookeeper</groupId>

--- a/tools/java-iceberg-cli/pom.xml
+++ b/tools/java-iceberg-cli/pom.xml
@@ -26,11 +26,6 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>org.apache.avro</groupId>
-                <artifactId>avro</artifactId>
-                <version>1.11.3</version>
-            </dependency>
-            <dependency>
                 <groupId>org.apache.zookeeper</groupId>
                 <artifactId>zookeeper</artifactId>
                 <version>3.9.1</version>
@@ -249,6 +244,11 @@
                 <groupId>org.apache.parquet</groupId>
                 <artifactId>parquet-avro</artifactId>
                 <version>1.12.3</version>
+            <dependency>
+                <groupId>org.apache.avro</groupId>
+                <artifactId>avro</artifactId>
+                <version>1.11.3</version>
+            </dependency>
             </dependency>
             <dependency>
                 <groupId>org.apache.hadoop</groupId>

--- a/tools/java-iceberg-cli/pom.xml
+++ b/tools/java-iceberg-cli/pom.xml
@@ -31,6 +31,11 @@
                 <version>1.4.12</version>
             </dependency>
             <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-classic</artifactId>
+                <version>1.4.12</version>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.zookeeper</groupId>
                 <artifactId>zookeeper</artifactId>
                 <version>3.9.1</version>

--- a/tools/java-iceberg-cli/src/main/java/iceberg_cli/utils/CliLogger.java
+++ b/tools/java-iceberg-cli/src/main/java/iceberg_cli/utils/CliLogger.java
@@ -5,6 +5,9 @@ import org.apache.log4j.ConsoleAppender;
 import org.apache.log4j.EnhancedPatternLayout;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.slf4j.Logger.ROOT_LOGGER_NAME;
 
 public class CliLogger {
 
@@ -21,6 +24,8 @@ public class CliLogger {
          */
         BasicConfigurator.configure();
         Logger.getRootLogger().setLevel(Level.OFF);
+        ch.qos.logback.classic.Logger slf4jLogger = (ch.qos.logback.classic.Logger) LoggerFactory.getLogger(ROOT_LOGGER_NAME);
+        slf4jLogger.setLevel(ch.qos.logback.classic.Level.OFF);
 
         /* Now setup our own logger which matches our typical logfile format. Since we
          * redirect stderr output to the log currently we'll setup a ConsoleAppender.


### PR DESCRIPTION
GitHub issue link:
https://github.com/IBM/java-iceberg-toolkit/issues/43
https://github.com/IBM/java-iceberg-toolkit/issues/44

Problem:
  The jars mentioned need to be upgraded to avoid security scan issues.

Solution:
Add dependency for zookeeper to version3.9.1
Add dependency for avro to 1.11.3
Add dependency for logback-core, logback-classic to 1.4.12
      (This is needed because the security scans show this as an issue after upgrading zookeeper and avro)

Testing:

- [* ] Unit tests 
- [ ] Additional tests (add results below)

[INFO] Results:
[INFO] 
[INFO] Tests run: 33, Failures: 0, Errors: 0, Skipped: 0


Documentation:
- [ *] Documentation not needed
- [ ] Updated README file
- [ ] Documentation prepared (provide link below)
