### PR TITLE
Fix CVE issues

### DIFF
--- a/tools/java-iceberg-cli/pom.xml
+++ b/tools/java-iceberg-cli/pom.xml
@@ -230,6 +230,12 @@
                 <groupId>org.apache.iceberg</groupId>
                 <artifactId>iceberg-arrow</artifactId>
                 <version>${org.apache.iceberg.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>io.netty</groupId>
+                        <artifactId>netty-common</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.apache.iceberg</groupId>
@@ -296,7 +302,7 @@
             <dependency>
                 <groupId>org.apache.hive</groupId>
                 <artifactId>hive-exec</artifactId>
-                <version>${org.apache.hive.version}</version>
+                <version>4.0.1</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.hadoop</groupId>

--- a/tools/java-iceberg-cli/pom.xml
+++ b/tools/java-iceberg-cli/pom.xml
@@ -541,6 +541,10 @@
                      <groupId>org.apache.hadoop.thirdparty</groupId>
                      <artifactId>hadoop-shaded-protobuf_3_7</artifactId>
                  </exclusion>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-transport-native-epoll</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/tools/java-iceberg-cli/pom.xml
+++ b/tools/java-iceberg-cli/pom.xml
@@ -14,10 +14,10 @@
         <de.ruedigermoeller.version>2.57</de.ruedigermoeller.version>
         <com.fasterxml.jackson.version>2.16.0</com.fasterxml.jackson.version>
         <org.eclipse.jetty.version>12.0.18</org.eclipse.jetty.version>
-        <org.apache.iceberg.version>1.8.1</org.apache.iceberg.version>
+        <org.apache.iceberg.version>1.4.2</org.apache.iceberg.version>
         <org.apache.hadoop.version>3.4.1</org.apache.hadoop.version>
-        <org.apache.hive.version>4.0.0-alpha-2</org.apache.hive.version>
-        <software.amazon.awssdk.version>2.17.272</software.amazon.awssdk.version>
+        <org.apache.hive.version>4.0.0-beta-1</org.apache.hive.version>
+        <software.amazon.awssdk.version>2.27.21</software.amazon.awssdk.version>
         <org.junit.jupiter.version>5.8.1</org.junit.jupiter.version>
         <org.apache.avro.version>1.11.4</org.apache.avro.version>
         <org.apache.zookeeper.version>3.9.2</org.apache.zookeeper.version>

--- a/tools/java-iceberg-cli/pom.xml
+++ b/tools/java-iceberg-cli/pom.xml
@@ -7,22 +7,22 @@
     <description>Java Iceberg CLI</description>
   
     <properties>
-        <io.netty.version>4.1.108.Final</io.netty.version>
+        <io.netty.version>4.1.118.Final</io.netty.version>
         <org.apache.calcite.avatica.version>1.23.0</org.apache.calcite.avatica.version>
         <org.apache.logging.log4j.version>2.20.0</org.apache.logging.log4j.version>
         <org.xerial.snappy.version>1.1.10.5</org.xerial.snappy.version>
         <de.ruedigermoeller.version>2.57</de.ruedigermoeller.version>
         <com.fasterxml.jackson.version>2.16.0</com.fasterxml.jackson.version>
-        <org.eclipse.jetty.version>11.0.18</org.eclipse.jetty.version>
-        <org.apache.iceberg.version>1.4.2</org.apache.iceberg.version>
-        <org.apache.hadoop.version>3.3.6</org.apache.hadoop.version>
-        <org.apache.hive.version>4.0.0-alpha-2</org.apache.hive.version>
+        <org.eclipse.jetty.version>12.0.18</org.eclipse.jetty.version>
+        <org.apache.iceberg.version>1.8.1</org.apache.iceberg.version>
+        <org.apache.hadoop.version>3.4.1</org.apache.hadoop.version>
+        <org.apache.hive.version>4.0.1</org.apache.hive.version>
         <software.amazon.awssdk.version>2.17.272</software.amazon.awssdk.version>
         <org.junit.jupiter.version>5.8.1</org.junit.jupiter.version>
-        <org.apache.avro.version>1.11.3</org.apache.avro.version>
+        <org.apache.avro.version>1.11.4</org.apache.avro.version>
         <org.apache.zookeeper.version>3.9.2</org.apache.zookeeper.version>
         <org.apache.derby.version>10.17.1.0</org.apache.derby.version>
-        <ch.qos.logback.version>1.4.14</ch.qos.logback.version>
+        <ch.qos.logback.version>1.5.13</ch.qos.logback.version>
         <com.jayway.jsonpath.version>2.9.0</com.jayway.jsonpath.version>
         <org.jline.version>3.25.0</org.jline.version>
         <org.apache.commons.version>1.26.0</org.apache.commons.version>
@@ -137,8 +137,8 @@
                 <version>${org.eclipse.jetty.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-webapp</artifactId>
+                <groupId>org.eclipse.jetty.ee10</groupId>
+                <artifactId>jetty-ee10-webapp</artifactId>
                 <version>${org.eclipse.jetty.version}</version>
             </dependency>
             <dependency>
@@ -260,6 +260,12 @@
                 <groupId>org.apache.hadoop</groupId>
                 <artifactId>hadoop-client</artifactId>
                 <version>${org.apache.hadoop.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.eclipse.jetty</groupId>
+                        <artifactId>jetty-io</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.apache.hadoop</groupId>
@@ -270,6 +276,12 @@
                 <groupId>org.apache.hadoop</groupId>
                 <artifactId>hadoop-common</artifactId>
                 <version>${org.apache.hadoop.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>io.netty</groupId>
+                        <artifactId>netty-handler</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.apache.hive</groupId>
@@ -419,8 +431,8 @@
             <artifactId>jetty-server</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-webapp</artifactId>
+            <groupId>org.eclipse.jetty.ee10</groupId>
+            <artifactId>jetty-ee10-webapp</artifactId>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
@@ -602,6 +614,11 @@
             <artifactId>junit-jupiter-params</artifactId>
             <version>${org.junit.jupiter.version}</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.5.18</version>
         </dependency>
     </dependencies>
 

--- a/tools/java-iceberg-cli/pom.xml
+++ b/tools/java-iceberg-cli/pom.xml
@@ -16,7 +16,7 @@
         <org.eclipse.jetty.version>12.0.18</org.eclipse.jetty.version>
         <org.apache.iceberg.version>1.8.1</org.apache.iceberg.version>
         <org.apache.hadoop.version>3.4.1</org.apache.hadoop.version>
-        <org.apache.hive.version>4.0.1</org.apache.hive.version>
+        <org.apache.hive.version>4.0.0-alpha-2</org.apache.hive.version>
         <software.amazon.awssdk.version>2.17.272</software.amazon.awssdk.version>
         <org.junit.jupiter.version>5.8.1</org.junit.jupiter.version>
         <org.apache.avro.version>1.11.4</org.apache.avro.version>

--- a/tools/java-iceberg-cli/src/main/java/iceberg_cli/HiveConnector.java
+++ b/tools/java-iceberg-cli/src/main/java/iceberg_cli/HiveConnector.java
@@ -205,7 +205,7 @@ public class HiveConnector extends MetastoreConnector
     @Override
     public boolean createNamespace(Namespace namespace) throws Exception, AlreadyExistsException, UnsupportedOperationException {
         // Get warehouse path
-        String warehouse = clients.run(client -> client.getConfigValue(HiveConf.ConfVars.METASTORE_WAREHOUSE.varname, null));
+        String warehouse = clients.run(client -> client.getConfigValue(HiveConf.ConfVars.METASTOREWAREHOUSE.varname, null));
         Database database = new Database(namespace.toString(), null, warehouse, new HashMap<String, String>());
         clients.run(
                 client -> {

--- a/tools/java-iceberg-cli/src/main/java/iceberg_cli/HiveConnector.java
+++ b/tools/java-iceberg-cli/src/main/java/iceberg_cli/HiveConnector.java
@@ -205,7 +205,7 @@ public class HiveConnector extends MetastoreConnector
     @Override
     public boolean createNamespace(Namespace namespace) throws Exception, AlreadyExistsException, UnsupportedOperationException {
         // Get warehouse path
-        String warehouse = clients.run(client -> client.getConfigValue(HiveConf.ConfVars.METASTOREWAREHOUSE.varname, null));
+        String warehouse = clients.run(client -> client.getConfigValue(HiveConf.ConfVars.METASTORE_WAREHOUSE.varname, null));
         Database database = new Database(namespace.toString(), null, warehouse, new HashMap<String, String>());
         clients.run(
                 client -> {


### PR DESCRIPTION
GitHub issue link:

Problem:
Several CVE vulnerabilities necessitated updating libraries and excluding specific packages to address potential security risks.

Solution:

**Libraires update:**
netty-> 4.1.118
eclipse.jetty->12.0.18
apache.hadoop->3.4.1
amazon.awssdk->2.27.21
apache.avro->1.11.4
qos.logback->1.5.13

**new imports or specific versions:**
logback-classic: 1.5.18
hive-exec: 4.0.1

**Libraires exclusion:**
from iceberg-arrow exclude netty-common
from hadoop-client exclude jetty-io
from io.netty excludenetty-handler
hadoop-shaded-protobuf_3_7 exclude netty-transport-native-epoll

Testing:
Unit test was run with hive metastore, AWS bucket 
hive metastore config included setting hive.metastore.disallow.incompatible.col.type.changes to false to allow drop. 
![image](https://github.com/user-attachments/assets/5859a2c5-0055-4356-bd39-5b55d0a9132e)

- [X] Unit tests 
- [ ] Additional tests (add results below)

Documentation:
- [ ] Documentation not needed
- [ ] Updated README file
- [ ] Documentation prepared (provide link below)
